### PR TITLE
Removed Alias from blueprint in this tutorial.

### DIFF
--- a/docs/content/guides/merge-delete.md
+++ b/docs/content/guides/merge-delete.md
@@ -51,8 +51,7 @@ clusters:
         ports:
           port: 8080/http
         environment_variables:
-          # using alias feature, instead of only "BACKEND: http://..."
-          backend[BACKEND]: http://$backend.host:$backend.ports.port/api/message
+          BACKEND: http://$backend.host:$backend.ports.port/api/message
         dependencies:
           backend: sava-backend:1.3.0
       scale:


### PR DESCRIPTION
It is not needed for deployment here and it is confusing, as it is not
explained what it is. I think alias should not be described in the tutorial, but probably
in some other part of the doc