### PR TITLE
Fixed issue with missing kubernetes bearer token

### DIFF
--- a/container_driver/src/main/scala/io/vamp/container_driver/kubernetes/KubernetesDriverActor.scala
+++ b/container_driver/src/main/scala/io/vamp/container_driver/kubernetes/KubernetesDriverActor.scala
@@ -44,6 +44,8 @@ class KubernetesDriverActor extends ContainerDriverActor with KubernetesContaine
 
   protected val apiUrl = KubernetesDriverActor.url
 
+  protected val token = KubernetesDriverActor.token
+
   protected val apiHeaders = {
     Try(Source.fromFile(token).mkString).map {
       bearer ⇒ ("Authorization" -> s"Bearer $bearer") :: HttpClient.jsonHeaders


### PR DESCRIPTION
This fixes an issue where the kubernetes service token can be set but wouldn't be used when making requests.