### PR TITLE
Added ssl support for VAMP API #988

### DIFF
--- a/http_api/src/main/resources/reference.conf
+++ b/http_api/src/main/resources/reference.conf
@@ -1,6 +1,8 @@
 vamp.http-api {
   port = 8080
   interface = 0.0.0.0
+  #ssl = true 
+  #certificate = /absolute/path/to/certificate.p12
   response-timeout = 10 seconds # HTTP response timeout
   strip-path-segments = 0
   sse.keep-alive-timeout = 15 seconds # timeout after an empty comment (":\n") will be sent in order keep connection alive


### PR DESCRIPTION
Enables SSL support for VAMP API
- Regular HTTP binding gets disabled when SSL (HTTPS) is enabled
- Requires valid PKCSmagneticio/vamp#12      certificate with no password