### PR TITLE
Replaced the --network argumet with --net 

### DIFF
--- a/dcos/src/main/scala/io/vamp/workflow_driver/MetronomeWorkflowActor.scala
+++ b/dcos/src/main/scala/io/vamp/workflow_driver/MetronomeWorkflowActor.scala
@@ -143,7 +143,7 @@ class MetronomeWorkflowActor extends WorkflowDriver with ContainerDriverValidati
       if (networkName == "BRIDGE") "bridge" else networkName
     }
 
-    val commandToRun = s"docker run $environmentVariablesAsString --network=${usedNetworkName} " +
+    val commandToRun = s"docker run $environmentVariablesAsString --net=${usedNetworkName} " +
       s"--rm ${workflow.breed.asInstanceOf[DefaultBreed].deployable.definition}"
 
     val workflowAsMetronomeJob = getJobRepresentation(workflowDescription = workflow.name, workflowId = workflowId,


### PR DESCRIPTION
Replaced the --network argumet with --net  so metronome-driver can work with older versions of docker