### PR TITLE
Bug fix: merging a deployment temporarily undeploys the internal gate…

### DIFF
--- a/operation/src/main/scala/io/vamp/operation/gateway/GatewaySynchronizationActor.scala
+++ b/operation/src/main/scala/io/vamp/operation/gateway/GatewaySynchronizationActor.scala
@@ -114,7 +114,7 @@ class GatewaySynchronizationActor extends CommonSupportForActors with ArtifactSu
       gateway.copy(routes = routes)
 
     } partition { gateway ⇒
-      gateway.routes.forall {
+      gateway.routes.exists {
         case route: DefaultRoute if route.targets.nonEmpty ⇒ targets(pipeline.deployable, deployments, route) == route.targets
         case _ ⇒ false
       } || !gateway.internal


### PR DESCRIPTION
…way resulting in 503 errors, closes #1072

Gateway gets deployed (HAProxy) only if it is ready - before all routes (corresponds to all cluster services) needed to be ready which resulted to temporal gateway removal. Now if at least one route is ready, gateway will be/stay deployed.