### PR TITLE
reference backward compatible nats actor in nats pulse actor mapper

### DIFF
--- a/nats/src/main/scala/io/vamp/pulse/NatsPulseActor.scala
+++ b/nats/src/main/scala/io/vamp/pulse/NatsPulseActor.scala
@@ -15,7 +15,7 @@ import scala.util.{ Random, Try }
 
 class NatsPulseActorMapper extends ClassMapper {
   val name = "nats"
-  val clazz: Class[_] = classOf[NatsPublisherPulseActor]
+  val clazz: Class[_] = classOf[NatsPulseActor]
 }
 
 object NatsPulseActor {


### PR DESCRIPTION
When we merge this pull request, we can also merge `VE-597/nats-test` in vamp-e2e-tests and `VE-597/Switch-to-Nats` in vamp-e2e-deploy, to enable NATS in end to end tests.